### PR TITLE
image(node): upgrade node:9.4-alpine to node:12-alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See it in action, below or try it out in your browser using this [Katacoda scena
 
 In addition to launching (Linux ELF) binaries directly, the following interpreted environments are currently supported:
 
-- When you enter `node script.js`, a Node.js (default version: 9.4) environment is provided and `script.js` is executed.
+- When you enter `node script.js`, a Node.js (default version: 12) environment is provided and `script.js` is executed.
 - When you enter `python script.py`, a Python (default version: 3.6) environment is provided and the `script.py` is executed.
 - When you enter `ruby script.rb`, a Ruby (default version: 2.5) environment is provided and the `script.rb` is executed.
 
@@ -190,7 +190,7 @@ Note that all three ways shown above are equivalent.
 `kubed-sh` supports environments and within it variables—akin to what your local shell (bash, zsh, fish) does. There are some pre-defined environment variables which influence the creation of the cluster processes you create by either specifying a binary or interpreter and script:
 
 - `BINARY_IMAGE` (default: `alpine:3.7`) … used for executing binaries
-- `NODE_IMAGE` (default: `node:9.4-alpine`) … used for executing Node.js scripts
+- `NODE_IMAGE` (default: `node:12-alpine`) … used for executing Node.js scripts
 - `PYTHON_IMAGE` (default: `python:3.6-alpine3.7`) … used for executing Python scripts
 - `RUBY_IMAGE` (default: `ruby:2.5-alpine3.7`) … used for executing Ruby scripts
 - `SERVICE_PORT` (default: `80`) … used to expose long-running processes within the cluster

--- a/cmdshelp.go
+++ b/cmdshelp.go
@@ -49,7 +49,7 @@ func helpall() {
 To run a program in the Kubernetes cluster, specify the binary
 or call it with one of the following supported interpreters:
 
-- Node.js … node script.js (default version: 9.4)
+- Node.js … node script.js (default version: 12)
 - Python … python script.py (default version: 3.6)
 - Ruby … ruby script.rb (default version: 2.5)
 `)

--- a/envs.go
+++ b/envs.go
@@ -20,7 +20,7 @@ type Environment struct {
 
 const (
 	defaultBinaryImage = "alpine:3.7"
-	defaultNodeImage   = "node:9.4-alpine"
+	defaultNodeImage   = "node:12-alpine"
 	defaultPythonImage = "python:3.6-alpine3.7"
 	defaultRubyImage   = "ruby:2.5-alpine3.7"
 )


### PR DESCRIPTION
This has some benefits.

1. Users will be able to use modern code without transpiling or configuring `NODE_IMAGE`.
2. As the new image is just `12`(not specifying minor version), a new feature(minor version up) and security patch(patch version up) will be automatically applied in the future, without any breaking change.
3. This is LTS version. Therefore there will be long-term stable support and update, which makes sense for `12` to be a default version.
4. In the code level, `12` is compatible with `9.4`(https://node.green/). Thus the majority of users who've been using the default version(`9.4`) do not have to manually configure `NODE_IMAGE` even with the new default version. 

This might close #24, but I'm not sure if other languages' default versions are be good to be changed.